### PR TITLE
KIO-966 Add Odoo test SSH host

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -338,6 +338,16 @@ in {
       forwardAgent = true;
       identityFile = "/home/${username}/.ssh/id_ed25519";
     };
+    grafana-reports = {
+      hostname = "192.168.1.109";
+      forwardAgent = true;
+    };
+    odoo-16-project-test = {
+      hostname = "192.168.0.32";
+      user = "kaertech";
+      forwardAgent = true;
+      identityFile = "/home/${username}/.ssh/id_ed25519";
+    };
   };
 
   programs.foot = {


### PR DESCRIPTION
## Summary
- add `odoo-16-project-test` SSH match block for CT 105
- enable agent forwarding for later custom module updates
- keep the same identity/user convention as existing Odoo test hosts

## Notes
- This branch also includes the existing uncommitted `grafana-reports` SSH block from the working tree because it was already present in `home.nix` and used as the pattern.
- `flake.lock` had unrelated local changes and was intentionally not included.

## Testing
- not run; `nixfmt` is not installed in the current shell